### PR TITLE
Add .hcl alternative extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
           "terraform"
         ],
         "extensions": [
-          ".tf"
+          ".tf",
+          ".hcl"
         ],
         "configuration": "./language-configuration.json"
       },


### PR DESCRIPTION
hcl is the default extension used for packer scripts converted to hcl syntax.  Without this change, it is necessary to manually select the file type of "terraform".

note: I'm not yet familiar with the vscode extension format, so I'm guessing this is where one specifies extensions.